### PR TITLE
Revert files to only Python>=3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.0.4] - 2024-05-03 01:35:00
+
+### Added
+
+- Revert files to Python 3.11 because the most recent Bokeh has some changes that don't work well with Python 3.10. We will just remove Google Colab.
+
+
 ## [0.0.3] - 2024-05-03 01:15:00
 
 ### Added
@@ -38,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This is the first release of the usempl-plots package.
 
 
+[0.0.4]: https://github.com/OpenSourceEcon/usempl-plots/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/OpenSourceEcon/usempl-plots/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/OpenSourceEcon/usempl-plots/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/OpenSourceEcon/usempl-plots/compare/v0.0.0...v0.0.1

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: usempl-plots-dev
 channels:
 - conda-forge
 dependencies:
-  - python>=3.10
+  - python>=3.11
   - ipython
   - numpy>=1.23.4
   - scipy>=1.9.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,5 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 79
-target-version = ["py310", "py311"]
+target-version = ["py311"]
 include = '\.pyi?$'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="usempl-plots",
-    version="0.0.3",
+    version="0.0.4",
     author="Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="Package for creating plots of US employment and unemployment",
@@ -21,7 +21,6 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: Information Analysis",
@@ -36,7 +35,7 @@ setup(
     packages=find_packages(),
     package_data={"usempl_plots": ["data/*"]},
     include_packages=True,
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     install_requires=[
         "numpy>=1.23.4",
         "scipy>=1.9.3",

--- a/usempl_plots/__init__.py
+++ b/usempl_plots/__init__.py
@@ -8,4 +8,4 @@ from usempl_plots.usempl_industry import *
 from usempl_plots.usempl_npp import *
 from usempl_plots.usempl_streaks import *
 
-__version__ = "0.0.2"
+__version__ = "0.0.4"


### PR DESCRIPTION
Revert the files to only Python >= 3.11. Bokeh has some updates that are not compatible with Python 3.11.